### PR TITLE
Fix code scanning alert no. 6: Prototype-polluting function

### DIFF
--- a/themes/fluid/scripts/utils/object.js
+++ b/themes/fluid/scripts/utils/object.js
@@ -18,7 +18,10 @@ const merge = (target, ...sources) => {
       if (!Object.prototype.hasOwnProperty.call(source, key)) {
         continue;
       }
-      if (isObject(target[key]) && isObject(source[key])) {
+      if (key === "__proto__" || key === "constructor") {
+        continue;
+      }
+      if (Object.prototype.hasOwnProperty.call(target, key) && isObject(target[key]) && isObject(source[key])) {
         merge(target[key], source[key]);
       } else {
         target[key] = source[key];


### PR DESCRIPTION
Fixes [https://github.com/wuliaodexiaoluo/wuliaodexiaoluo.github.io/security/code-scanning/6](https://github.com/wuliaodexiaoluo/wuliaodexiaoluo.github.io/security/code-scanning/6)

To fix the problem, we need to modify the `merge` function to prevent prototype pollution. This can be achieved by blocking the special properties `__proto__` and `constructor` from being merged or assigned to. Additionally, we should ensure that only own properties of the destination object are merged recursively.

1. Modify the `merge` function to include checks that block the `__proto__` and `constructor` properties.
2. Ensure that only own properties of the destination object are merged recursively.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
